### PR TITLE
Fix version of Vue to 2.6.14

### DIFF
--- a/start-page/index.html
+++ b/start-page/index.html
@@ -9,7 +9,9 @@
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
         crossorigin="anonymous">
 
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
+        integrity="sha256-kXTEJcRFN330VirZFl6gj9+UM6gIKW195fYZeR3xDhc="
+        crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
As Vue 3 has just become default and it contain major changes to the API of Vue so the application no longer bootstrap.